### PR TITLE
Mongoose 6.x forward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mongoose.model('mySchema', schema);
 ```
 Now we instantiate the Mongoose Avro Schema Generator with a the mongoose instance.
 ```js
-const Generator = require('mongoose-avro-schema-generator');
+const Generator = require('@researchgate/mongoose-avro-schema-generator');
 const mongooseAvroSchemaGenerator = new Generator(mongoose);
 ```
 Then `mongooseAvroSchemaGenerator.generate()` will output an array of all generated schemas.

--- a/src/generator.js
+++ b/src/generator.js
@@ -82,7 +82,7 @@ class Generator {
                 },
             },
             {
-                sources: [mongoose.Schema.Types.ObjectId],
+                sources: [mongoose.Schema.Types.ObjectId, 'ObjectId'],
                 typeDefinition: {
                     type: AVRO_TYPE_STRING,
                     subtype: 'objectid',


### PR DESCRIPTION
Thanks for taking the time to file a pull request with us.
Please take a moment to provide the following details:

When running with Mongoose 5.x and 6.x, there will be an error.
> Error: An error occured while parsing schema "test": Unable to parse entity auto: true

## Description
The root cause is ObjectId object is a primitive object instead of `mongoose.Schema.Types.ObjectId`.
Therefore, it has to add a new identifier for ObjectId.

## Motivation and context
It can fix #27 

## How has this been tested?
`npm run test`

## Screenshots (if relevant):

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
